### PR TITLE
remove unneeded </ul>

### DIFF
--- a/wunderlist.py
+++ b/wunderlist.py
@@ -119,7 +119,6 @@ def generateEmail(config):
 			else:
 				text+='<li>'+each[i][1]+'</li>'
 
-		text+='</UL>'
 	text+='</HTML>'
 
 	text_file = open('TEST_EMAIL.html', 'w')


### PR DESCRIPTION
To be fair, using `<li>` tags without an enclosing `<ul>` is not valid HTML, but will render properly in most modern browsers. 
